### PR TITLE
New Calendar Activity Intent Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -115,5 +115,30 @@ var SendIntentAndroid = require('react-native-send-intent');
 SendIntentAndroid.sendPhoneDial('+55 48 9999-9999');
 ```
 
+## Example / Create Calendar Event
+
+According to [Google](http://developer.android.com/guide/topics/providers/calendar-provider.html#intents) using Intents for
+ inserting, updating, and viewing calendar events is the preferred method.  At this time only simple **recurrence** is
+ supported ['daily'|'weekly'|'monthly'|'yearly'].
+
+Create a Calendar Event:
+
+```javascript
+// Create the Calendar Intent.
+SendIntentAndroid.sendAddCalendarEvent({
+  title: 'Go To The Park',
+  description: "It's fun to play at the park.",
+  startDate: '2016-01-25 10:00',
+  endDate: '2016-01-25 11:00',
+  recurrence: 'weekly'
+});
+```
+
+## Example / Open Calendar
+
+```javascript
+SendIntentAndroid.sendOpenCalendar();
+```
+
 ## License
 MIT

--- a/index.js
+++ b/index.js
@@ -27,6 +27,12 @@ var SendIntentAndroid = {
     },
     sendSms(phoneNumber, body) {
         RNSendIntentAndroid.sendSms(phoneNumber, (body||null));
+    },
+    sendAddCalendarEvent(config) {
+        RNSendIntentAndroid.sendAddCalendarEvent(config.title, config.description, config.startDate, config.endDate, config.recurrence);
+    },
+    sendOpenCalendar() {
+        RNSendIntentAndroid.sendOpenCalendar();
     }
 };
 

--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ var SendIntentAndroid = {
     sendSms(phoneNumber, body) {
         RNSendIntentAndroid.sendSms(phoneNumber, (body||null));
     },
-    sendAddCalendarEvent(config) {
+    addCalendarEvent(config) {
         RNSendIntentAndroid.sendAddCalendarEvent(config.title, config.description, config.startDate, config.endDate, config.recurrence);
     },
-    sendOpenCalendar() {
+    openCalendar() {
         RNSendIntentAndroid.sendOpenCalendar();
     }
 };

--- a/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -136,7 +136,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void sendAddCalendarEvent(String title, String description, String startDate, String endDate, String recurrence) {
+    public void addCalendarEvent(String title, String description, String startDate, String endDate, String recurrence) {
 
       Calendar startCal = Calendar.getInstance();
       SimpleDateFormat sdf = new SimpleDateFormat("y-MMMM-d H:m");
@@ -171,7 +171,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void sendOpenCalendar() {
+    public void openCalendar() {
       ComponentName cn = new ComponentName("com.android.calendar", "com.android.calendar.LaunchActivity");
 
       Intent sendIntent = new Intent()

--- a/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -176,7 +176,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
 
       Intent sendIntent = new Intent()
           .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-          .setComponent(cn);
+          .setType("vnd.android.cursor.item/event");
 
       if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
           this.reactContext.startActivity(sendIntent);


### PR DESCRIPTION
Good day, 

Thank you for developing this great React Native module.  It's very useful for sharing text and sending messages.  

I added a couple of methods to enable creating Calendar events because it was a feature I need for one of my own apps.  I thought it could be useful for others and wanted to get my small changes merged with your module if at all possible. Are you accepting pull requests?

I'm don't have a lot of Java/Android experience so if there's any adjustments that need to be made please let me know.  I've tested things out in a simulator and on an actual device and it worked great for me.

Thanks again,
Adam