### PR TITLE
Open Maps feature added

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -240,12 +240,6 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
       //Check that an app exists to receive the intent
       if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
         this.reactContext.startActivity(sendIntent);
-      } else {
-        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmmIntentUri);
-        mapIntent.setPackage("com.google.android.apps.maps");
-        if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
-          this.reactContext.startActivity(mapIntent);
-        }
       }
     }
 }

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -230,4 +230,22 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
             currentActivity.startActivity(Intent.createChooser(intent, title));
         }
     }
+
+    @ReactMethod
+    public void openMaps(String query) {
+      Uri gmmIntentUri = Uri.parse("geo:0,0?q="+query);
+      Intent sendIntent = new Intent(android.content.Intent.ACTION_VIEW, gmmIntentUri);
+      sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+      //Check that an app exists to receive the intent
+      if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
+        this.reactContext.startActivity(sendIntent);
+      } else {
+        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmmIntentUri);
+        mapIntent.setPackage("com.google.android.apps.maps");
+        if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
+          this.reactContext.startActivity(mapIntent);
+        }
+      }
+    }
 }

--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ var SendIntentAndroid = {
     openChooserWithOptions(options: Object, title: string) {
       RNSendIntentAndroid.openChooserWithOptions(options, title);
     },
+    openMaps(query) {
+        RNSendIntentAndroid.openMaps(query);
+    }
 };
 
 module.exports = SendIntentAndroid;


### PR DESCRIPTION
I've added a new function that opens the map on device with the given query string. Example usage: 
`SendIntentAndroid.openMaps('Piccadilly Circus Station, London, United Kingdom');   `

The solution is based on this document: https://developers.google.com/maps/documentation/android-api/intents
And it currently sending requests in the following format: geo:0,0?q={query}