### PR TITLE
Add video sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Opens Androids default share tray:
     subject: 'Story Title',
     text: 'Message Body'
   }, 'Share Story');
+
+  SendIntentAndroid.openChooserWithOptions({
+    subject: 'Video Title',
+    videoUrl: '/path_or_url/to/video.mp4'
+  }, 'Share video to');
+
 ```
 
 ## Example / Open Maps

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -252,6 +252,14 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
             Uri uri = Uri.parse(options.getString("imageUrl"));
             intent.putExtra(Intent.EXTRA_STREAM, uri);
             intent.setType("image/*");
+        } else if (options.hasKey("videoUrl")) {
+            File media = new File(options.getString("videoUrl"));
+            Uri uri = Uri.fromFile(media);
+            if(!options.hasKey("subject")) {
+              intent.putExtra(Intent.EXTRA_SUBJECT,"Untitled_Video");
+            }
+            intent.putExtra(Intent.EXTRA_STREAM, uri);
+            intent.setType("video/*");
         } else {
             intent.setType("text/plain");
         }


### PR DESCRIPTION
This will allow apps to share videos to other apps.

* a known annoyance is that the thumbnail may show up in the wrong orientation. i.e. when shooting a portrait mode video and sharing it will likely be a rotated thumbnail but the video will play in the correct orientation.