### PR TITLE
Import missing java.io.File

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.lang.SecurityException;
 import java.text.SimpleDateFormat;
 import java.text.ParseException;
+import java.io.File;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.NativeModule;


### PR DESCRIPTION
When building it throws the following error.
```java
error: cannot find symbol class File
```

The error is related to the `RNSendIntentModule.java:256`.
```java
File media = new File(options.getString("videoUrl"));
```