### PR TITLE
Add ability to install remote apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,16 @@ SendIntentAndroid.addCalendarEvent({
 Check if Gmail app is intalled. Returns a promise with a boolean telling if the app is installed or not
 
 ```javascript
-SendIntentAndroid.isAppInstallaed('com.google.android.gm').then((isInstalled) => {});
+SendIntentAndroid.isAppInstalled('com.google.android.gm').then((isInstalled) => {});
+```
+
+## Example / Install a remote APK
+
+This can be used to upgrade your APK from a custom source or install other apps.
+No additional permissions are required.
+
+```javascript
+SendIntentAndroid.installRemoteApp('https://example.com/my-app.apk', 'my-saved-app.apk').then((installWasStarted) => {});
 ```
 
 ## Example / Open App

--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ var SendIntentAndroid = {
     isAppInstalled(packageName) {
         return RNSendIntentAndroid.isAppInstalled(packageName);
     },
+    installRemoteApp(uri, saveAs) {
+        return RNSendIntentAndroid.installRemoteApp(uri, saveAs);
+    },
     openApp(packageName, extras) {
         return RNSendIntentAndroid.openApp(packageName, (extras || {}));
     },


### PR DESCRIPTION
This is a commonly requested feature, when looking online, but nobody I've found has a working solution.

Examples of people trying:

* https://stackoverflow.com/questions/5952516/install-apk-from-url
* https://stackoverflow.com/questions/4967669/android-install-apk-programmatically
* https://stackoverflow.com/questions/4604239/install-application-programmatically-on-android
* https://github.com/wkh237/react-native-fetch-blob (offers a [broken solution](https://github.com/wkh237/react-native-fetch-blob/issues/394#issuecomment-339435773))
* https://stackoverflow.com/questions/20553138/android-install-packages-permission-and-non-playstore-apps
* https://stackoverflow.com/questions/6813322/install-uninstall-apks-programmatically-packagemanager-vs-intents

OkHTTP was used since React Native already uses it and its interface is relatively straightforward.