### PR TITLE
Allow SDK versions to be overridden

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,25 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext;
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+';
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 23;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '23.0.1';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 22;
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 19
         versionName "1.0.26"
     }
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    provided "com.facebook.react:react-native:${_reactNativeVersion}"
 }
-


### PR DESCRIPTION
This is a common pattern now, recommended by Google, in the following documentation: https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties

Many other libraries are taking the same approach, as shown in the following:

* https://github.com/react-native-community/react-native-linear-gradient/pull/232
* https://github.com/react-community/react-native-maps/pull/2047
* https://github.com/transistorsoft/react-native-background-geolocation/blob/master/android/build.gradle#L3
* https://github.com/rebeccahughes/react-native-device-info/blob/master/android/build.gradle#L3