### PR TITLE
Set openFileChooser permission in Android 8+

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,21 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.burnweb.rnsendintent">
+
+    <application>
+        <service
+                android:name=".RNSendIntentModule"
+                android:exported="true" />
+        <provider
+                android:name="android.support.v4.content.FileProvider"
+                android:authorities="${applicationId}.fileprovider"
+                android:exported="false"
+                android:grantUriPermissions="true">
+
+            <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/file_paths" />
+
+        </provider>
+
+    </application>
 </manifest>

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -9,6 +9,8 @@ import android.provider.CalendarContract.Events;
 import android.os.Environment;
 import android.util.Log;
 import android.net.Uri;
+import android.os.Build;
+import android.support.v4.content.FileProvider;
 import android.telephony.TelephonyManager;
 import android.content.Context;
 
@@ -658,7 +660,12 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
         }
 
         File fileUrl = new File(options.getString("fileUrl"));
-        intent.setDataAndType(Uri.fromFile(fileUrl), options.getString("type"));
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+            Uri uri = FileProvider.getUriForFile(this.reactContext, this.reactContext.getPackageName() + ".fileprovider", fileUrl);
+            intent.setDataAndType(uri, options.getString("type"));
+        } else {
+            intent.setDataAndType(Uri.fromFile(fileUrl), options.getString("type"));
+        }
 
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         Activity currentActivity = getCurrentActivity();

--- a/android/src/main/res/xml/file_paths.xml
+++ b/android/src/main/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path name="files" path="/" />
+</paths>


### PR DESCRIPTION
Fix the bug `Exception in native call android.os.FileUriExposedException: file:///** exposed beyond app through Intent.getData()` in `openFileChooser` API

## Reason
Android 7.0 behavior changes Share files between applications through FileProvider

We can add `this hook`↓↓↓, and dont forget add `.fileprovider` for Specify file storage address. By the way,it is also work for `installRemoteApp` API😀
```java
if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
  Uri uri = FileProvider.getUriForFile(this.reactContext, this.reactContext.getPackageName() + ".fileprovider", fileUrl);
  intent.setDataAndType(uri, options.getString("type"));
} else {
  intent.setDataAndType(Uri.fromFile(fileUrl), options.getString("type"));
}
```