### PR TITLE
Fix: Calling startActivity() from outside of an Activity context

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -670,6 +670,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void openEmailApp() {
       Intent sendIntent = new Intent(Intent.ACTION_MAIN);
+      sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       sendIntent.addCategory(Intent.CATEGORY_APP_EMAIL);
       if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
           this.reactContext.startActivity(sendIntent);


### PR DESCRIPTION
After upgrading to latest React Native (0.60.4).
App start crashing with: `Calling startActivity() from outside of an Activity context`, upon calling `SendIntentAndroid.openEmailApp();` method.

I did follow fix from here: https://stackoverflow.com/questions/3918517/calling-startactivity-from-outside-of-an-activity-context

Maybe there might be better approaches?

> OT: Also RN itself now supports `Linking.sendIntent()`, so would be nice to have this moved to RN repo, or community.