### PR TITLE
change file profile for suport android x

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/FileProvider.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/FileProvider.java
@@ -1,4 +1,4 @@
 package com.burnweb.rnsendintent;
 
-public class FileProvider extends android.support.v4.content.FileProvider {
+public class FileProvider extends androidx.core.content.FileProvider {
 }

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -10,7 +10,7 @@ import android.os.Environment;
 import android.util.Log;
 import android.net.Uri;
 import android.os.Build;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.telephony.TelephonyManager;
 import android.content.Context;
 


### PR DESCRIPTION
Updated the class extended by the FileProvider class to support Android X, I had trouble using this lib in React Native version 0.60.5 and was able to resolve by doing this in class.

