### PR TITLE
fix typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,75 @@
-export function sendText(config)
-export function sendPhoneCall(phoneNumber, phoneAppOnly?: boolean)
-export function sendPhoneDial(phoneNumber, phoneAppOnly?: boolean)
-export function sendSms(phoneNumber, body)
-export function addCalendarEvent(config)
-export function isAppInstalled(packageName)
-export function installRemoteApp(uri, saveAs)
-export function openCalendar()
-export function sendMail(mail, subject?: string, body?: string)
-export function openChooserWithOptions(options, title)
-export function openChooserWithMultipleOptions(options, title)
-export function openMaps(query)
-export function openCamera()
-export function openMapsWithRoute(query, mode)
-export function shareTextToLine(options)
-export function shareImageToInstagram(type, mediaPath)
-export function openSettings(settingsName)
-export function getVoiceMailNumber()
-export function getPhoneNumber()
-export function openApp(packageName: string, extras: { [index: string]: string })
-export function openAppWithData(packageName: string, dataUri: string, mimeType?: string, extras?: { [index: string]: string }): Promise<boolean>
-export function openChromeIntent(dataUri: string): Promise<boolean>
-export function openFileChooser(options, title)
-export function openEmailApp()
+declare namespace SendIntentAndroid {
+  type TextType = typeof TEXT_HTML | typeof TEXT_PLAIN
+
+  interface TextIntentConfig {
+      title: string
+      text: string
+      type: TextType
+  }
+
+  interface CalendarEventConfig {
+          title: string
+          description: string
+          /**
+           * A datetime string with following format: yyyy-MM-dd HH:mm
+           */
+          startDate: string
+          /**
+           * A datetime string with following format: yyyy-MM-dd HH:mm
+           */
+          endDate: string
+          recurrence?: 'daily' | 'weekly' | 'monthly' | 'yearly'
+          location: string
+          /**
+           * **default**: false
+           */
+          isAllDay?: boolean
+  }
+
+  interface ChooserOptions {
+      subject?: string
+      text?: string
+      imageUrl?: string
+      videoUrl?: string
+  }
+
+  interface TextToLineOptions {
+      text?: string
+  }
+
+  interface FileChooserOptions {
+      fileUrl: string
+      subject?: string
+      type: string
+  }
+
+  const sendText: (config: TextIntentConfig) => void
+  const sendPhoneCall: (phoneNumber: string, phoneAppOnly?: boolean) => void
+  const sendPhoneDial: (phoneNumber: string, phoneAppOnly?: boolean) => void
+  const sendSms: (phoneNumber: string, body?: string|null) => void
+  const addCalendarEvent: (config: CalendarEventConfig) => void
+  const isAppInstalled: (packageName: string) => Promise<boolean>
+  const installRemoteApp: (uri: string, saveAs: string) => Promise<boolean>
+  const openCalendar: () => void
+  const sendMail: (recepientMail: string, subject?: string, body?: string) => void
+  const openChooserWithOptions: (options: ChooserOptions, title: string) => void
+  const openChooserWithMultipleOptions: (options: ChooserOptions[], title: string)=> void
+  const openMaps: (query: string)=> void
+  const openCamera: ()=> void
+  const openMapsWithRoute: (query: string, mode: string)=> void
+  const shareTextToLine: (options: TextToLineOptions)=> void
+  const shareImageToInstagram: (mimeType: string, mediaPath: string) => void
+  const openSettings: (settingsName: string) => void
+  const getVoiceMailNumber: () => Promise<string>
+  const getPhoneNumber: () => Promise<string>
+  const openApp: (packageName: string, extras: { [index: string]: string }) => void
+  const openAppWithData: (packageName: string, dataUri: string, mimeType?: string, extras?: { [index: string]: string }) => Promise<boolean>
+  const openChromeIntent: (dataUri: string) => Promise<boolean>
+  const openDownloadManager: () => void
+  const openFileChooser: (options: FileChooserOptions, title: string) => void
+  const openEmailApp: () => void
+  const TEXT_PLAIN: unique symbol
+  const TEXT_HTML: unique symbol
+}
+
+export = SendIntentAndroid


### PR DESCRIPTION
**Typescript definitions were broken and inaccurate:**

- the module exported default instead of 'export =', which was not
reflecting the source code;
- many methods didn't provide a return type, causing build errors;
- many methods didn't provide arguments types.

**Summary of changes:**

- create a namespace encapsulating all types and methods;
- export this namespace via direct module.exports assignment to reflect
source code;
- add missing config / option definitions;
- provide exhaustive method signatures;
- add missing openDownloadManager method.

**Tests**

I did a test in a project consuming this library.

*Before patch (46 errors)*

![Screenshot_20191017_084312](https://user-images.githubusercontent.com/3646758/67005955-38db7300-f0ba-11e9-9a02-b817b7089d95.png)

*After patch (0 errors)*

![Screenshot_20191017_084349](https://user-images.githubusercontent.com/3646758/67005995-54df1480-f0ba-11e9-8c5f-1b178ad03d65.png)
