### PR TITLE
Remove dupe openEmailApp() method

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -800,16 +800,6 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void openEmailApp() {
-      Intent sendIntent = new Intent(Intent.ACTION_MAIN);
-      sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      sendIntent.addCategory(Intent.CATEGORY_APP_EMAIL);
-      if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
-          this.reactContext.startActivity(sendIntent);
-      }
-    }
-
-    @ReactMethod
     public void requestIgnoreBatteryOptimizations(final Promise promise) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PowerManager pm = (PowerManager) this.reactContext.getSystemService(Context.POWER_SERVICE);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-send-intent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "React Native Android module to use Android's Intent actions for send sms, text to shareable apps, open custom apps, make phone calls and etc",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bom dia!

After upgrading to RN 0.6x, the java compiler is erroring out because the `openEmailApp()` is defined twice.

Not sure why this just started happening, since it appears they have both existed in the file for a year or so, but seeing that both definitions are exact dupes, it seems safe to remove one of them.