### PR TITLE
Fix sendMail

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -322,11 +322,11 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void sendMail(String recepientString, String subject, String body) {
-      String uriText = "mailto:" + Uri.encode(recepientString) +
-            "?body=" + Uri.encode(body) +
-            "&subject=" + Uri.encode(subject);
-
-      Intent sendIntent = new Intent(Intent.ACTION_SENDTO, Uri.parse(uriText));
+      Intent sendIntent = new Intent(Intent.ACTION_SENDTO);
+      sendIntent.setData(Uri.parse("mailto:"));
+      sendIntent.putExtra(Intent.EXTRA_EMAIL, new String[]{recepientString});
+      sendIntent.putExtra(Intent.EXTRA_SUBJECT, subject);
+      sendIntent.putExtra(Intent.EXTRA_TEXT, body);
       sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
       //Check that an app exists to receive the intent


### PR DESCRIPTION
Changed the way the email intent was launched. Previously, a link was built and passed to the intent. Now, it's done the same way as the official documentation example, that can be seen [here](https://developer.android.com/guide/components/intents-common.html#ComposeEmail).

This fixes issue #117 