### PR TITLE
Add type definition for openAppWithUri

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ declare namespace SendIntentAndroid {
   const openAllEmailApp: () => void
   const requestIgnoreBatteryOptimizations: () => Promise<boolean>
   const showIgnoreBatteryOptimizationsSettings: () => void
+  const openAppWithUri: (intentUri: string, extras?: { [index: string]: string }) => Promise<boolean>
   const TEXT_PLAIN: unique symbol
   const TEXT_HTML: unique symbol
 }


### PR DESCRIPTION
Our team is using Typescript for our project, and I thought it would be really helpful for us and to other people as well if the newly added function `openAppWithUri` could provide type definitions.

It's a simple addition to the `index.d.ts` file, and won't take much time to review this I hope.

Thank you for your awesome package!