### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 }
 
 dependencies {
-    provided "com.facebook.react:react-native:${_reactNativeVersion}"
+    compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
Hello,

I am getting the warning below when using this module in my app. I have fixed it with the recommendation. It builds fine after the change.

> Configure project :react-native-send-intent
WARNING: Configuration 'provided' is obsolete and has been replaced with 'compileOnly'.
It will be removed soon. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html