### PR TITLE
Update openFileChooser to work on apps with requestLegacyExternalStorage disabled

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -729,7 +729,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
             intent.setDataAndType(Uri.fromFile(fileUrl), options.getString("type"));
         }
 
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         Activity currentActivity = getCurrentActivity();
         if (currentActivity != null) {
             currentActivity.startActivity(Intent.createChooser(intent, title));


### PR DESCRIPTION
Android apps targeting Android 11 (API level 30) [can no longer use the `requestLegacyExternalStorage` attribute](https://developer.android.com/about/versions/11/privacy/storage#scoped-storage). This impacts apps that want to open a file chooser with a `fileUrl` directed at a file within the app's own storage. Explicit permission needs to be granted to the Action View Intent through the `Intent.FLAG_GRANT_READ_URI_PERMISSION` flag.

[This article](https://commonsware.com/blog/2016/08/31/granting-permissions-uri-intent-extra.html) gives a good explanation on this flag and how it should be used.

The code below would not work for an app with `requestLegacyExternalStorage` disabled prior to this PR.

```js
SendIntentAndroid.openFileChooser(
      {
        fileUrl: '/storage/emulated/0/Android/data/com.example.app/files/Download/example.pdf',
        type: 'application/pdf'
      },
      'Open File with:',
    );
```