### PR TITLE
feat(add-open-settings-uri-context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ Opens a specified settings screen when passed one of the constant values availab
 SendIntentAndroid.openSettings("android.settings.SECURITY_SETTINGS");
 ```
 
+Opening settings that require app package id uri
+
+```javascript
+SendIntentAndroid.openSettings("android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION", "package:<your_app_package_id>);
+```
+
 ## Example / Get voiceMail number
 
 Please add this line to your AndroidManifest.xml file before using next example:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdkVersion _minSdkVersion
         targetSdkVersion _targetSdkVersion
         versionCode 28
-        versionName "1.3.0"
+        versionName "1.3.1"
     }
 }
 

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -703,9 +703,17 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
 
     }
 
+
     @ReactMethod
-    public void openSettings(String screenName) {
-        Intent settingsIntent = new Intent(screenName);
+    public void openSettings(String screenName, String uriString) {
+        Intent settingsIntent;
+        if (uriString != null){
+            uri = new Uri.parse(uriString)
+            settingsIntent = new Intent(screenName, uri);
+        } else {
+            settingsIntent = new Intent(screenName);
+        }
+
         settingsIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         if (settingsIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -708,7 +708,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     public void openSettings(String screenName, String uriString) {
         Intent settingsIntent;
         if (uriString != null){
-            uri = new Uri.parse(uriString);
+            Uri uri = Uri.parse(uriString);
             settingsIntent = new Intent(screenName, uri);
         } else {
             settingsIntent = new Intent(screenName);

--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -708,7 +708,7 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     public void openSettings(String screenName, String uriString) {
         Intent settingsIntent;
         if (uriString != null){
-            uri = new Uri.parse(uriString)
+            uri = new Uri.parse(uriString);
             settingsIntent = new Intent(screenName, uri);
         } else {
             settingsIntent = new Intent(screenName);

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare namespace SendIntentAndroid {
   const openMapsWithRoute: (query: string, mode: string)=> void
   const shareTextToLine: (options: TextToLineOptions)=> void
   const shareImageToInstagram: (mimeType: string, mediaPath: string) => void
-  const openSettings: (settingsName: string) => void
+  const openSettings: (settingsName: string, uri?: string) => void
   const getVoiceMailNumber: () => Promise<string>
   const getPhoneNumber: () => Promise<string>
   const gotoHomeScreen: () => void

--- a/index.js
+++ b/index.js
@@ -68,8 +68,8 @@ var SendIntentAndroid = {
     shareImageToInstagram(type, mediaPath) {
         RNSendIntentAndroid.shareImageToInstagram(type, mediaPath);
     },
-    openSettings(settingsName) {
-        RNSendIntentAndroid.openSettings(settingsName);
+    openSettings(settingsName, uri = null) {
+        RNSendIntentAndroid.openSettings(settingsName, uri);
     },
     getVoiceMailNumber() {
         return RNSendIntentAndroid.getVoiceMailNumber();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-send-intent",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "React Native Android module to use Android's Intent actions for send sms, text to shareable apps, open custom apps, make phone calls and etc",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- support passing uri into the openSettings so menus such as file manager permissions can open with the settings intent
- add uri option parameter to all sections of the app.
- default uri to null if not provided by the API and pass the null value to the native side.

Questions:
- Is there a way to test these changes? I'm not able to build the gradle project.
- Can we add documentation for how to build this repo?

Edit:
- I tested this in my own repo doing install like so ```"react-native-send-intent": "git+https://github.com/FrederickEngelhardt/react-native-send-intent/#feat/add-open-settings-uri-context"```. FYI with this method cache is nasty. Run this if you need to make updates `yarn cache clean react-native-send-intent`. Symlinks can also work but they require metro workarounds.

I tested this and links work well. So I think this feature is stable. Without the URI nothing will navigate but that's fine.

Example code

```
    const uri = `package:<package.name>` // must be your test app's package that requires this permission
    openSettings('android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION', uri)
```